### PR TITLE
o3DS compatibility status, redirect old links

### DIFF
--- a/dumping.md
+++ b/dumping.md
@@ -2,13 +2,14 @@
 
 There are various different methods that KeySAVᵉ can use to access and decrypt your data, each with their own unique requirements and advantages. From most convenient to least convenient these are:
 
-  1. [Decrypted Saves](/dumping/decrypted-saves.md) - required Homebrew, a CFW or a Cybersaves device.
-  2. [TEA](/dumping/tea.md) - dump the Pokémon shown to you in a trade. Useful mainly for helping other users. Requires NTR CFW, to get it, you must already have a CFW, if you don't know what this means, you don't have one. For Generation 7 games, usage of a n3DS is required.
-  3. [Encrypted Saves](/dumping/encrypted-saves.md) - requires a digital copy (Generation 6 & 7) or a physical copy and a Powersaves device (Generation 6 only as of now).
-  4. [Battle videos](/dumping/battle-videos.md) - requires an SD card reader and someone who is willing to battle you every time you want to dump Pokémon (or a second console). Checks up to six Pokémon at once.
-  5. [YABD (Legacy)](/dumping/yabd.md) - requires a 3DS between 9.0.0 and 9.5.0 and only works for Generation 6 games.
+1. [Decrypted Saves](/dumping/decrypted-saves.md) - requires Homebrew, a CFW or a Cybersaves device.
+2. [TEA](/dumping/tea.md) - dump the Pokémon shown to you in a trade. Useful mainly for helping other users. Requires NTR CFW, to get it, you must already have a CFW, if you don't know what this means, you don't have one.
+3. [Encrypted Saves](/dumping/encrypted-saves.md) - requires a digital copy \(Generation 6 & 7\) or a physical copy and a Powersaves device \(Generation 6 only as of now\).
+4. [Battle videos](/dumping/battle-videos.md) - requires an SD card reader and someone who is willing to battle you every time you want to dump Pokémon \(or a second console\). Checks up to six Pokémon at once.
+5. [YABD \(Legacy\)](/dumping/yabd.md) - requires a 3DS between 9.0.0 and 9.5.0 and only works for Generation 6 games.
 
 # Advanced topics
 
 Want to output your Pokémon differently? Have a look at the different [formatting options](/formatting)!  
 Looking for something specific? Check out the [filters](/filters).
+

--- a/dumping/decrypted-saves.md
+++ b/dumping/decrypted-saves.md
@@ -2,9 +2,9 @@
 
 Using Homebrew, a CFW or a Cybersaves device you can access the decrypted save data of your game directly. Creating a key is not required.
 
-Since the requirements for Homebrew are numerous and you have a lot of different option, this guide will not get into details of how to get Homebrew. Instead I recommend you go to [Smea's website](http://smealum.github.io/3ds/) [ez3ds](https://ez3ds.xyz) or check out [Plailect's guide](https://3ds.guide/). The latter covers a lot of things beyond getting Homebrew, feel free to just not read the other parts at all.
+Since the requirements for Homebrew are numerous and you have a lot of different options, this guide will not get into details of how to get Homebrew. Instead I recommend you go to [Smea's website](http://smealum.github.io/3ds/) [ez3ds](https://ez3ds.xyz) or check out [Plailect's guide](https://3ds.guide/). The latter covers a lot of things beyond getting Homebrew, feel free to just not read the other parts at all.
 Once you have access to Homebrew, you can dump your saves using [JKSM](https://gbatemp.net/threads/release-jks-savemanager-homebrew-cia-save-manager.413143/) and open them in KeySAVᵉ.
-When using the Homebrew launcher to open a save manager, you have to select the game that you want to dump the save from, before you start the application. Once you select the save manager, you can choose the game with the left and right buttons on your d-pad.
+When using the Homebrew launcher to open a save manager, you have to select the game that you want to dump the save from before you start the application. Once you select the save manager, you can choose the game with the left and right buttons on your d-pad.
 You can also install JKSM as a CIA if you have a CFW.  
 A Cybersaves device can be used to extract decrypted saves from Japanese game cartridges. Please consult other tutorials for instructions how to obtain the save. Once you have your `main`-File, you can open it in KeySAVᵉ.
 Please make sure never to save any data in the KeySAVᵉ folder itself.

--- a/dumping/encrypted-saves.md
+++ b/dumping/encrypted-saves.md
@@ -15,6 +15,7 @@ You will be required to create backups of your save in this process. If you are 
 * Powersaves and a physical copy, insert the game cartridge into the device, start the software , click on the `BACKUP` button and name the backup. The file will be located in `C:\Users\<YourUsernameHere>\Powersaves3DS` if you use Windows or `~/Documents/Powersaves3DS` if you use a Mac.
 * a digital copy, the saves are stored on the SD card of your 3DS in a folder specific to the game. First go to `Nintendo 3DS/<ID>/<ID>`, where `<ID>` are folders unique to your 3DS. If you are using X, the path from there is `title/00040000/00055d00/data`. For Y, it is `title/00040000/00055e00/data`. For OR, it is `title/00040000/0011C400/data`. For AS, it is `title/00040000/0011C500/data`. For Sun it is `title/00040000/00164800/data`, for Moon it is `title/00040000/00175e00/data`. Copy the file there to a folder of your choice on your PC and rename it as you wish. Never save any data to the KeySAVᵉ folder itself.
 
+
 1. Locate six Pokémon that you caught or breed yourself. They have to originate from the save that you are trying to create a key for. If you can't find enough, catch new ones.
 2. Put them into the first row of the first box in your computer.
 3. Save your game.

--- a/dumping/tea.md
+++ b/dumping/tea.md
@@ -9,8 +9,10 @@ If you get your Pokémon checked with TEA, please make sure to only show your pa
 ## Setup
 
 * Make sure you have KeySAVᵉ 1.2.0 (1.4.0 for Generation 7 games) or later. If you currently have version 1.1.1 or later, you will receive an update, otherwise please [download a new version](https://github.com/Cu3PO42/KeySAVe/releases).
-* Install NTR CFW on your 3DS. This requires that you currently run a CFW such as Luma3DS. If your 3DS is on version 11.0 or later, you will need a hardmod to obtain this, otherwise you can follow the first three parts of [this guide](https://github.com/Plailect/Guide/wiki). Once you have a CFW, install [this](https://github.com/astronautlevel2/BootNTR/releases/latest) CIA file and copy the `ntr.bin` from [here](https://github.com/44670/BootNTR/files/222950/NTR_3.4PREVIEW2_STARTER_KIT.zip) if you are on a N3DS, or from [here](https://github.com/44670/BootNTR/releases/download/3.2/NTR.3.2.zip) if you are on an O3DS to the root of your SD card.
-* If you want to use TEA with Generation 7 games, usage of a New 3DS required, it will not work on an Old 3DS!
+* Install NTR CFW on your 3DS. This requires that you currently run a CFW such as Luma3DS. If your 3DS is on version 11.3 or later, you will need a hardmod to obtain this, otherwise you can follow [this guide](https://3ds.guide/). Once you have a CFW, install [this](https://github.com/Nanquitas/BootNTR/releases) CIA file.
+    * TEA can be used with both Generation 6 and Generation 7 games, but each generation requires a different version of NTR CFW.
+    * NTR is used for Generation 6, and NTR Mode 3 is used for Generation 7.
+    * For maximum convenience, install both CIA files. Load the appropriate NTR CFW before launching your game.
 * Find out your 3DS' IP address in your local network. You can either check in your router's configuration interface (I am unable to provide assistance for this) or start one of the many FTP clients for 3DS. Your IP will be on the top screen.
 
 ## Dumping Pokémon

--- a/dumping/yabd.md
+++ b/dumping/yabd.md
@@ -23,6 +23,6 @@ Special credits go to SciresM on whose code this is based and Yifanlu for revers
 
 ## A final note to everyone who still uses this method
 
-At the time of writing this it has been almost been a year since the spider exploits have been patched. If you are still using this, you have access to Homebrew and can downgrade to 9.2.0 and run a CFW which will still allow easy checking, but also allow you to use your 3DS online again. I recommend you follow the first three parts of [Plailect's guide to A9LH](https://github.com/Plailect/Guide/wiki) for this.
+At the time of writing this it has been almost been a year since the spider exploits have been patched. If you are still using this, you have access to Homebrew and can downgrade to 9.2.0 and run a CFW which will still allow easy checking, but also allow you to use your 3DS online again. I recommend you follow [Plailect's guide](https://3ds.guide/) for this.
 
 {% include "footer.md" %}

--- a/formatting/handlebars.md
+++ b/formatting/handlebars.md
@@ -55,7 +55,7 @@ Your templates can contain arbitrary HTML that will be rendered. Any expression 
 |`heldItem`||
 |`tid`|The TID as it would be shown by the game.|
 |`sid`||
-|`tid7`|The TID as used in Generation 6 and previous ones.|
+|`tid6`|The TID as used in Generation 6 and previous ones.|
 |`tid7`|The TID as used in Generation 7.|
 |`tsv`||
 |`esv`||


### PR DESCRIPTION
Added more information on using TEA with o3DS and Generation 7 games.
Changed link to NTR CFW.
Redirected old links to the new 3ds.guide web page.
Minor spelling changes and formatting changes for clarity.

Please confirm the change in formatting/handlebars.md.